### PR TITLE
Feature - Add EasyAuthRouter default permissions

### DIFF
--- a/docs/client_usage.md
+++ b/docs/client_usage.md
@@ -50,10 +50,10 @@ async def startup():
     {'groups': ['administrators']}
 
 ### APIRouter
-FastAPI provides a [APIRouter](https://fastapi.tiangolo.com/tutorial/bigger-applications/?h=apirouter#apirouter) object for defining path prefixes, pre-defined dependencies, see fastapi docs for more details. EasyAuthClient can extend the main FastAPI router using the .create_api_router() method. 
+FastAPI provides a [APIRouter](https://fastapi.tiangolo.com/tutorial/bigger-applications/?h=apirouter#apirouter) object for defining path prefixes, pre-defined dependencies, see fastapi docs for more details. EasyAuthClient can extend the main FastAPI router using the .create_api_router() method or EasyAuthAPIRouter.create(). 
 
-!!! Important - "APIRouter Considerations "
-    APIRouter's must be created and distributed at runtime, instead of just imported & included.
+!!! Important - "EasyAuthAPIRouter Considerations "
+    EasyAuthAPIRouter should be created after an `EasyAuthClient` or `EasyAuthServer` is created to ensure that the router are correctly included and visible in OpenAPI schema.  
 
 ```python
 from fastapi import FastAPI, Request, Depends
@@ -74,37 +74,28 @@ async def startup():
         default_permissoins={'groups': ['users']}
     )
 
-    finance_auth_router = server.auth.create_api_router(prefix='/finance', tags=['finance'])
-    hr_auth_router = server.auth.create_api_router(prefix='/hr', tags=['hr'])
-    marketing_auth_router = server.auth.create_api_router(prefix='/marketing', tags=['marketing'])
-
     # import sub modules
     from .finance import finance
     from .hr import hr
     from .marketing import marketing
-
-    # send auth routers to setup of each sub-module
-    await finance.setup(finance_auth_router)
-    await hr.setup(hr_auth_router)
-    await marketing.setup(marketing_auth_router)
 ```
 
 ```python
-#finance/finance.py
-# finance setup
-async def setup(router):
+from easyauth.router import EasyAuthAPIRouter
 
-    @router.get('/')
-    async def finance_root():
-        return f"fiance_root"
-    
-    @router.get('/data')
-    async def finance_data():
-        return f"finance_data"
+finance_router = EasyAuthAPIRouter.create(prefix='/finance', tags=['finance'])
+
+@finance_router.get('/')
+async def finance_root():
+    return f"fiance_root"
+
+@finance_router.get('/data')
+async def finance_data():
+    return f"finance_data"
 
 ```
 !!! TIP
-    server.auth.create_api_router() is a wrapper around FastAPI's APIRouter, accepting and passing the same arguments, but also automatically including the router at startup.
+    EasyAuthAPIRouter.create() and server.auth.create_api_router() are wrappers around FastAPI's APIRouter, accepting and passing the same arguments, but also automatically including the router at startup.
 
 ```
 .

--- a/docs/server_usage.md
+++ b/docs/server_usage.md
@@ -73,12 +73,11 @@ test_key.key  test_key.pub
 ### APIRouter
 FastAPI provides an [APIRouter](https://fastapi.tiangolo.com/tutorial/bigger-applications/?h=apirouter#apirouter) object for defining path prefixes, pre-defined dependencies, see fastapi docs for more details. EasyAuthServer can extend the main FastAPI router using the <b>.create_api_router()</b> method. 
 
-!!! Important - "APIRouter Considerations "
-    APIRouter's must be created and distributed at runtime, instead of just imported & included.
+!!! Important - "EasyAuthAPIRouter Considerations "
+    EasyAuthAPIRouter should be created after an `EasyAuthClient` or `EasyAuthServer` is created to ensure that the router are correctly included and visible in OpenAPI schema.  
 
 ```python
 from fastapi import FastAPI
-
 from easyauth.server import EasyAuthServer
 
 server = FastAPI()
@@ -94,33 +93,24 @@ async def startup():
         env_from_file='server_sqlite.json'
     )
 
-    finance_auth_router = server.auth.create_api_router(prefix='/finance', tags=['finance'])
-    hr_auth_router = server.auth.create_api_router(prefix='/hr', tags=['hr'])
-    marketing_auth_router = server.auth.create_api_router(prefix='/marketing', tags=['marketing'])
-
     # import sub modules
     from .finance import finance
     from .hr import hr
     from .marketing import marketing
-
-    # send auth routers to setup of each sub-module
-    await finance.setup(finance_auth_router)
-    await hr.setup(hr_auth_router)
-    await marketing.setup(marketing_auth_router)
 ```
 
 ```python
-#finance/finance.py
-# finance setup
-async def setup(router):
+from easyauth.router import EasyAuthAPIRouter
 
-    @router.get('/')
-    async def finance_root():
-        return f"fiance_root"
-    
-    @router.get('/data')
-    async def finance_data():
-        return f"finance_data"
+finance_router = EasyAuthAPIRouter.create(prefix='/finance', tags=['finance'])
+
+@router.get('/')
+async def finance_root():
+    return f"fiance_root"
+
+@router.get('/data')
+async def finance_data():
+    return f"finance_data"
 
 ```
 !!! TIP

--- a/easyauth/__init__.py
+++ b/easyauth/__init__.py
@@ -1,3 +1,0 @@
-from .server import EasyAuthServer
-from .client import EasyAuthClient
-from .router import EasyAuthAPIRouter

--- a/easyauth/client.py
+++ b/easyauth/client.py
@@ -210,7 +210,7 @@ class EasyAuthClient:
                     transform_id='RegisterUser'
                 )
             )
-        @server.post('/register', response_class=HTMLResponse, tags='User')
+        @server.post('/register', response_class=HTMLResponse, tags=['User'])
         async def admin_register_send(user_info: dict):
             return await auth_server.rpc_server['easyauth']['register_user'](
                 user_info
@@ -231,7 +231,7 @@ class EasyAuthClient:
                 )
             )
 
-        @server.post('/activate', response_class=HTMLResponse, tags='User')
+        @server.post('/activate', response_class=HTMLResponse, tags=['User'])
         async def admin_activate_send(activation_code: ActivationCode):
             return await auth_server.rpc_server['easyauth']['activate_user'](
                 activation_code.dict()
@@ -535,7 +535,14 @@ class EasyAuthClient:
             route(path, *args, **kwargs)(mock_function)
             return mock_function
         return auth_endpoint
-    def parse_permissions(self, users, groups, roles, actions):
+    def parse_permissions(self, users, groups, roles, actions, default_permissions):
+        """
+        returns permssions defined on a given endpoint if set
+        if unset
+            returns router dedfault permissions
+        if no router defaults
+            return EasyAuthClient default permissions
+        """
         permissions = {}
         if users:
             permissions['users'] = users
@@ -545,8 +552,9 @@ class EasyAuthClient:
             permissions['roles'] = roles
         if actions:
             permissions['actions'] = actions
+        
         if not permissions:
-            permissions = self.DEFAULT_PERMISSION
+            permissions = self.DEFAULT_PERMISSION if not default_permissions else default_permissions
         return permissions
         
     def get(

--- a/easyauth/router.py
+++ b/easyauth/router.py
@@ -11,19 +11,24 @@ class EasyAuthAPIRouter:
     def __init__(self,
         parent, # EasyAuthClient or EasyAuthServer,
         api_router: APIRouter,
+        default_permissions: dict = None
     ):
         self.parent = parent
         self.server = api_router
+        self.parent.server.include_router(api_router)
         self.log = parent.log
+        self.default_permissions = default_permissions
     @classmethod
     def create(cls,
+        default_permissions: dict = None,
         *args, 
         **kwargs
     ):
         api_router = APIRouter(*args, **kwargs)
         auth_api_router = cls(
             cls.parent,
-            api_router
+            api_router,
+            default_permissions
         )
         return auth_api_router
     def router(self, path, method, permissions: list, send_token: bool = False, *args, **kwargs):
@@ -172,7 +177,7 @@ class EasyAuthAPIRouter:
         *args, 
         **kwargs
     ):
-        permissions = self.parent.parse_permissions(users, groups, roles, actions)
+        permissions = self.parent.parse_permissions(users, groups, roles, actions, self.default_permissions)
         return self.router(path, 'get', permissions=permissions, send_token=send_token, *args, **kwargs)
     def post(
         self, 
@@ -185,7 +190,7 @@ class EasyAuthAPIRouter:
         *args, 
         **kwargs
     ):
-        permissions = self.parent.parse_permissions(users, groups, roles, actions)
+        permissions = self.parent.parse_permissions(users, groups, roles, actions, self.default_permissions)
         return self.router(path, 'post', permissions=permissions, send_token=send_token, *args, **kwargs)
     def update(
         self, 
@@ -198,7 +203,7 @@ class EasyAuthAPIRouter:
         *args, 
         **kwargs
     ):
-        permissions = self.parent.parse_permissions(users, groups, roles, actions)
+        permissions = self.parent.parse_permissions(users, groups, roles, actions, self.default_permissions)
         return self.router(path, 'udpate', permissions=permissions, send_token=send_token, *args, **kwargs)
     def delete(
         self, 
@@ -211,7 +216,7 @@ class EasyAuthAPIRouter:
         *args, 
         **kwargs
     ):
-        permissions = self.parent.parse_permissions(users, groups, roles, actions)
+        permissions = self.parent.parse_permissions(users, groups, roles, actions, self.default_permissions)
         return self.router(path, 'delete', permissions=permissions, send_token=send_token, *args, **kwargs)
     def put(
         self, 
@@ -224,7 +229,7 @@ class EasyAuthAPIRouter:
         *args, 
         **kwargs
     ):
-        permissions = self.parent.parse_permissions(users, groups, roles, actions)
+        permissions = self.parent.parse_permissions(users, groups, roles, actions, self.default_permissions)
         return self.router(path, 'put', permissions=permissions, send_token=send_token, *args, **kwargs)
     def patch(
         self, 
@@ -237,7 +242,7 @@ class EasyAuthAPIRouter:
         *args, 
         **kwargs
     ):      
-        permissions = self.parent.parse_permissions(users, groups, roles, actions)
+        permissions = self.parent.parse_permissions(users, groups, roles, actions, self.default_permissions)
         return self.router(path, 'patch', permissions=permissions, send_token=send_token, *args, **kwargs)
     def options(
         self, 
@@ -250,7 +255,7 @@ class EasyAuthAPIRouter:
         *args,
         **kwargs
     ):      
-        permissions = self.parent.parse_permissions(users, groups, roles, actions)
+        permissions = self.parent.parse_permissions(users, groups, roles, actions, self.default_permissions)
         return self.router(path, 'options', permissions=permissions, send_token=send_token, *args, **kwargs)
     def head(
         self, 
@@ -263,5 +268,5 @@ class EasyAuthAPIRouter:
         *args, 
         **kwargs
     ):      
-        permissions = self.parent.parse_permissions(users, groups, roles, actions)
+        permissions = self.parent.parse_permissions(users, groups, roles, actions, self.default_permissions)
         return self.router(path, 'head', permissions=permissions, send_token=send_token, *args, **kwargs)

--- a/easyauth/router.py
+++ b/easyauth/router.py
@@ -15,7 +15,7 @@ class EasyAuthAPIRouter:
     ):
         self.parent = parent
         self.server = api_router
-        self.parent.server.include_router(api_router)
+        self.parent.api_routers.append(self)
         self.log = parent.log
         self.default_permissions = default_permissions
     @classmethod

--- a/easyauth/server.py
+++ b/easyauth/server.py
@@ -883,7 +883,14 @@ class EasyAuthServer:
         return auth_endpoint
 
 
-    def parse_permissions(self, users, groups, roles, actions):
+    def parse_permissions(self, users, groups, roles, actions, default_permissions):
+        """
+        returns permssions defined on a given endpoint if set
+        if unset
+            returns router dedfault permissions
+        if no router defaults
+            return EasyAuthServer default permissions
+        """
         permissions = {}
         if users:
             permissions['users'] = users
@@ -894,7 +901,7 @@ class EasyAuthServer:
         if actions:
             permissions['actions'] = actions
         if not permissions:
-            permissions = self.DEFAULT_PERMISSION
+            permissions = self.DEFAULT_PERMISSION if not default_permissions else default_permissions
         return permissions
         
     def get(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,11 +2,10 @@ import os
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from easyauth import EasyAuthServer
+from easyauth.server import EasyAuthServer
+from easyauth.router import EasyAuthAPIRouter
 # import sub modules
-from .finance import finance
-from .hr import hr
-from .marketing import marketing
+
 
 @pytest.mark.asyncio
 @pytest.fixture()
@@ -26,17 +25,12 @@ async def auth_test_client():
             env_from_file='tests/server_sqlite.json'
         )
 
-        finance_auth_router = server.auth.create_api_router(prefix='/finance', tags=['finance'])
-        hr_auth_router = server.auth.create_api_router(prefix='/hr', tags=['hr'])
-        marketing_auth_router = server.auth.create_api_router(prefix='/marketing', tags=['marketing'])
+        from .finance import finance
+        from .hr import hr
+        from .marketing import marketing
 
-        # send auth routers to setup of each sub-module
-        await finance.setup(finance_auth_router)
-        await hr.setup(hr_auth_router)
-        await marketing.setup(marketing_auth_router)
-        #nothings
-
-        test_auth_router = server.auth.create_api_router(prefix='/testing', tags=['testing'])
+        #test_auth_router = server.auth.create_api_router(prefix='/testing', tags=['testing'])
+        test_auth_router = EasyAuthAPIRouter.create(prefix='/testing', tags=['testing'])
 
         # grants access to users matching default_permissions
         @test_auth_router.get('/default')

--- a/tests/finance/finance.py
+++ b/tests/finance/finance.py
@@ -1,10 +1,14 @@
-# finance setup
-async def setup(router):
+from easyauth.router import EasyAuthAPIRouter
 
-    @router.get('/')
-    async def finance_root():
-        return f"fiance_root"
-    
-    @router.get('/data')
-    async def finance_data():
-        return f"finance_data"
+finance_router = EasyAuthAPIRouter.create(prefix='/finance', tags=['finance'])
+
+@finance_router.get('/')
+async def finance_root():
+    return f"fiance_root"
+
+@finance_router.get('/data')
+async def finance_data():
+    return f"finance_data"
+
+
+print(f"finance setup")

--- a/tests/hr/hr.py
+++ b/tests/hr/hr.py
@@ -1,10 +1,13 @@
-# hr setup
-async def setup(router):
+from easyauth.router import EasyAuthAPIRouter
 
-    @router.get('/')
-    async def hr_root():
-        return f"hr_root"
-    
-    @router.get('/data')
-    async def hr_data():
-        return f"hr_data"
+hr_router = EasyAuthAPIRouter.create(prefix='/hr', tags=['hr'])
+
+@hr_router.get('/')
+async def hr_root():
+    return f"hr_root"
+
+@hr_router.get('/data')
+async def hr_data():
+    return f"hr_data"
+
+print(f"hr setup")

--- a/tests/marketing/marketing.py
+++ b/tests/marketing/marketing.py
@@ -1,10 +1,13 @@
-# marketing setup
-async def setup(router):
+from easyauth.router import EasyAuthAPIRouter
 
-    @router.get('/')
-    async def marketing_root():
-        return f"marketing_root"
-    
-    @router.get('/data')
-    async def marketing_data():
-        return f"marketing_data"
+marketing_router = EasyAuthAPIRouter.create(prefix='/marketing', tags=['marketing'])
+
+@marketing_router.get('/')
+async def marketing_root():
+    return f"marketing_root"
+
+@marketing_router.get('/data')
+async def marketing_data():
+    return f"marketing_data"
+
+print(f"marketing setup")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -10,5 +10,9 @@ async def startup():
         server,
         '/auth/token',
         auth_secret='abcd1234',
-        env_from_file='server_sqlite.json'
+        env_from_file='tests/server_sqlite.json'
     )
+
+    from tests.finance import finance
+    from tests.hr.hr import hr_router
+    from tests.marketing import marketing


### PR DESCRIPTION
## Description
This PR provides `EasyAuthRouter` with a `default_permission` argument which is similar to `EasyAuthServer` and `EasyAuthClient` that define  default permissions for endpoints which are not specified. `EasyAuthRouter` is also improved by automatically including its APIRouter in its parent `EasyAuthClient` or `EasyAuthServer`. 
