### PR TITLE
Feature - Expired token cleanup

### DIFF
--- a/easyauth/client.py
+++ b/easyauth/client.py
@@ -238,7 +238,14 @@ class EasyAuthClient:
             )
 
         @server.post('/auth/token/oauth/google', include_in_schema=False)
-        async def create_google_oauth_token(request: Request, response: Response, redirect: bool = True):
+        async def create_google_oauth_token(
+            request: Request, 
+            response: Response, 
+            redirect: bool = True,
+            include_token: bool = False,
+        ):
+
+
             google_client_type = request.headers.get("X-Google-OAuth2-Type")
 
             if google_client_type == 'client':
@@ -258,13 +265,18 @@ class EasyAuthClient:
             
             if redirect: 
                 return RedirectResponse(redirect_ref, headers=response.headers, status_code=HTTP_302_FOUND)
-            else:
-                decoded_token = auth_server.decode_token(token)[1]
-                return HTMLResponse(
-                    content=json.dumps({'exp': decoded_token['exp'], 'auth': True}), 
-                    status_code=200, 
-                    headers=response.headers
-                )
+    
+            # not redirecting 
+            
+            decoded_token = auth_server.decode_token(token)[1]
+            response_body = {'exp': decoded_token['exp'], 'auth': True}
+            if include_token:
+                response_body['token'] = token
+            return HTMLResponse(
+                content=json.dumps(response_body), 
+                status_code=200, 
+                headers=response.headers
+            )
 
         @server.get("/logout", tags=['Login'], response_class=HTMLResponse, include_in_schema=False)
         async def logout_page(

--- a/easyauth/proxy.py
+++ b/easyauth/proxy.py
@@ -40,7 +40,7 @@ def manager_proxy_setup(server):
             client_methods = manager['clients']
             log.warning(f"triggering global_store_update for {client_methods}")
             for method in client_methods:
-                if method in 'get_store_data': 
+                if method == 'get_store_data': 
                     continue
                 if 'token_cleanup' in method:
                     continue 

--- a/easyauth/proxy.py
+++ b/easyauth/proxy.py
@@ -1,5 +1,7 @@
 import os
+import asyncio
 from easyrpc.server import EasyRpcServer
+from easyschedule import EasyScheduler
 
 def manager_proxy_setup(server):
 
@@ -29,6 +31,7 @@ def manager_proxy_setup(server):
             **rpc_config
         )
         log = manager.log
+        manager.scheduler = EasyScheduler()
 
         @manager.origin(namespace='manager')
         async def global_store_update(action, store, key, value):
@@ -37,11 +40,31 @@ def manager_proxy_setup(server):
             client_methods = manager['clients']
             log.warning(f"triggering global_store_update for {client_methods}")
             for method in client_methods:
-                if method == 'get_store_data': 
+                if method in 'get_store_data': 
                     continue
+                if 'token_cleanup' in method:
+                    continue 
+
                 try:
                     result = await client_methods[method](action, store, key, value)
                 except Exception as e:
                     log.exception(f"error with {method} on k: {key} - v: {value} in {store}")
 
             return "global_store_update - completed"
+        
+        @manager.scheduler(schedule='*/15 * * * *')
+        async def global_token_cleanup():
+            """
+            triggers check and cleanup of expired tokens
+            """
+            client_methods = manager['clients']
+            log.debug(f"triggering global_token_cleanup for {client_methods}")
+            for method in client_methods:
+                if not 'token_cleanup' in method:
+                    continue
+                result = await client_methods[method]()
+                log.debug(f"global_token_cleanup: cleaned {len(result)} expired tokens")
+                break
+        
+        # start scheduler in background
+        asyncio.create_task(manager.scheduler.start())

--- a/easyauth/router.py
+++ b/easyauth/router.py
@@ -88,7 +88,7 @@ class EasyAuthAPIRouter:
             async def mock_function(*args, **kwargs):
                 request = kwargs['request']
                 token = kwargs['token']
-                if token ==  'NO_TOKEN':
+                if token ==  'NO_TOKEN' or token == 'INVALID':
                     if response_class is HTMLResponse or 'text/html' in request.headers['accept']:
                         response = HTMLResponse(
                             await self.parent.get_login_page(

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ gunicorn==20.1.0
 email-validator==1.1.3
 easyrpc==0.245
 google-api-python-client==2.26.1
+easyschedule==0.107

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ BASE_REQUIREMENTS = [
 SERVER_REQUIREMENTS = [
     'pydbantic>=0.0.14', 'cryptography==35.0.0', 
     'bcrypt==3.2.0', 'uvloop', 
+    'easyschedule==0.107',
     'example==0.1.0', 'httptools==0.3.0',
     'gunicorn==20.1.0', 'fastapi-mail==0.3.7',
     'email-validator==1.1.3', 'google-api-python-client==2.31.0'


### PR DESCRIPTION
## New Feature - Expired Token Cleanup
This PR introduces expired token cleanup which is needed to ensure that tokens are not filling up a database when they are no longer used. Before this feature, tokens need to be manually revoked on GUI or via API. 

- Implemented expired token cleanup task on EasyAuthServers which revokes(delete & notifies clients of token cleanup) to be run every 15 minutes via Scheduler

## Improvements 
- Added additonal path argument to /auth/token/oauth/google (google oauth token exchange) include_token=False(default), when used with redirect=False, will return created token in JSON body instead of just setting cookie