### PR TITLE
Improvement - Cookie Security (Secure & SameSite) & JWT Key Usage

### DIFF
--- a/easyauth/api.py
+++ b/easyauth/api.py
@@ -173,7 +173,7 @@ async def api_setup(server):
     ):
         token = await server.generate_google_oauth_token(request)
         # add token to cookie
-        response.set_cookie('token', token)
+        response.set_cookie('token', token, **server.cookie_security)
 
         redirect_ref = server.ADMIN_PREFIX
 
@@ -290,7 +290,8 @@ async def api_setup(server):
         token = await server.issue_token(permissions)
 
         # add token to cookie
-        response.set_cookie('token', token)
+        
+        response.set_cookie('token', token, **server.cookie_security)
 
         redirect_ref = server.ADMIN_PREFIX
 
@@ -304,14 +305,14 @@ async def api_setup(server):
     async def logout_page(
         response: Response
     ):
-        response.set_cookie('token', 'INVALID')
+        response.set_cookie('token', 'INVALID', **server.cookie_security)
         return RedirectResponse('/login', headers=response.headers)
 
     @server.server.post("/logout", tags=['Login'], response_class=HTMLResponse)
     async def logout_page_post(
         response: Response,
     ):
-        response.set_cookie('token', 'INVALID')
+        response.set_cookie('token', 'INVALID', **server.cookie_security)
         return RedirectResponse('/login/re', headers=response.headers)
 
     @server.server.post("/auth/user/activate")

--- a/easyauth/server.py
+++ b/easyauth/server.py
@@ -64,7 +64,9 @@ class EasyAuthServer:
         manager_proxy_port: int = 8092,
         debug: bool = False,
         env_from_file: str = None,
-        default_permission: dict = {'groups': ['administrators']}
+        default_permission: dict = {'groups': ['administrators']},
+        secure: bool = False,
+        private_key: str = None
     ):
         self.server = server
         self.server.title = admin_title
@@ -73,6 +75,9 @@ class EasyAuthServer:
         self.DEFAULT_PERMISSION = default_permission
 
         self.rpc_server = rpc_server
+
+        # cookie security
+        self.cookie_security = {'secure': secure, 'samesite': "lax" if not secure else "none"}
 
         # logging setup # 
         self.log = logger
@@ -96,7 +101,10 @@ class EasyAuthServer:
         assert 'KEY_NAME' in os.environ, f"missing KEY_NAME env variable"
 
         # setup keys
-        self.key_setup()
+        if not private_key:
+            self.key_setup()
+        else:
+            self._privkey = jwk.JWK.from_json(private_key)
 
         # setup allowed origins - where can server receive token requests from
         self.cors_setup()
@@ -192,7 +200,9 @@ class EasyAuthServer:
         manager_proxy_port: int = 8092,
         debug: bool = False,
         env_from_file: str = None,
-        default_permission: dict = {'groups': ['administrators']}
+        default_permission: dict = {'groups': ['administrators']},
+        secure: bool = False,
+        private_key: str = None
     ):
 
         rpc_server = EasyRpcServer(
@@ -211,7 +221,9 @@ class EasyAuthServer:
             manager_proxy_port,
             debug,
             env_from_file,
-            default_permission
+            default_permission,
+            secure,
+            private_key
         )
 
         await database_setup(auth_server)


### PR DESCRIPTION
## Description
This PR expands Cookie CORS Usability by enabling `secure=True` to `EasyAuthServer.create(` and `EasyAuthClient.create(`  factory methods. EasyAuthServer.create(` also has a new optional argument `private_key` which can be used to set a private_key at runtime instead of using from from or generating a new key pair.

### Cookie CORS improvments
-  added new EasyAuthServer & EasyAuthClient create parameters for cookie-security, secure=True|False(Default) will determine whether the set-cookie header also contains secure flag to ensure usage on https connections as well as removing SameSite requirements lax -> none for secure=True.


### JWT - Key Changes
- Added new argument to EasyAuthServer for private_key, which expects a JSON string of a generated EasyAuth private key, allowing for input from external secret sources at runtime
