### PR TITLE
Page and Path overloads

### DIFF
--- a/docs/client_usage.md
+++ b/docs/client_usage.md
@@ -17,7 +17,7 @@ async def startup():
         token_server='0.0.0.0',
         token_server_port=8090,
         auth_secret='abcd1234',
-        default_permissoins={'groups': ['users']}
+        default_permissions={'groups': ['users']}
     )
 
     # grants access to users matching default_permissions
@@ -71,7 +71,7 @@ async def startup():
         token_server='0.0.0.0',
         token_server_port=8090,
         auth_secret='abcd1234',
-        default_permissoins={'groups': ['users']}
+        default_permissions={'groups': ['users']}
     )
 
     # import sub modules
@@ -139,3 +139,74 @@ EasyAuth client endpoints, decorated by the auth router, that serve HTML respons
     Once logged in, the browser will contain a authenticatin cookie that matches the users token
 
 ![](images/cookie.png)
+
+
+### Page Overloads
+It is possible to overload the existing login, register, activation, not_found, and forbidden pages using the page specific "overloader". Just like routers, this should be done after an EasyAuthClient is created.
+
+!!! Danger
+    Consider reviewing what API's are used / required before overloading any existing page. Oauth Login scripts are not loaded into overloaded pages.
+
+#### Not Found - 404
+```python
+from easyauth.pages import NotFoundPage
+
+@NotFoundPage.mark()
+def custom_not_found_page():
+    return "Custom 404 Page"
+
+```
+!!! TIP
+    `NotFoundPage` contents is wrapped in an HTMLResponse with a status_code `404`.
+
+#### Forbidden Page - 403
+```python
+from easyauth.pages import ForbiddenPage
+
+@ForbiddenPage.mark()
+def not_allowed_page():
+    return "Custom 404 Page"
+```
+#### Login Page & 401
+```python
+from easyauth.pages import LoginPage
+
+@LoginPage.mark()
+def custom_login_page():
+    return "Custom Login Page"
+
+```
+
+#### Register Page
+```python
+from easyauth.pages import RegisterPage
+
+@RegisterPage.mark()
+def custom_register_page():
+    return "Custom Register Page"
+
+```
+
+#### Activation Page
+```python
+from easyauth.pages import ActivationPage
+
+@ActivationPage.mark()
+def custom_activation_page():
+    return "Custom Login Page"
+
+```
+
+### Path Overloads
+The default `/login` and 401 redirect path can be overloaded by setting the `default_login_path` on `EasyAuthClient.create()`.
+
+```python
+    server.auth = await EasyAuthClient.create(
+        server,
+        token_server='0.0.0.0',
+        token_server_port=8090,
+        auth_secret='abcd1234',
+        default_permissions={'groups': ['users']},
+        default_login_path='/v1/internal/login'
+    )
+```

--- a/docs/server_usage.md
+++ b/docs/server_usage.md
@@ -256,3 +256,60 @@ $ cat /etc/hosts
 ![](images/oauth-error.png)
 
 Updating Browser Path to overriden host path, login should then be possible if correctly configured in google console
+
+
+### Page Overloads
+It is possible to overload the existing login, register, activation, not_found, and forbidden pages using the page specific "overloader". Just like routers, this should be done after an EasyAuthClient is created.
+
+!!! Danger
+    Consider reviewing what API's are used / required before overloading any existing page. Oauth Login scripts are not loaded into overloaded pages.
+
+#### Not Found - 404
+```python
+from easyauth.pages import NotFoundPage
+
+@NotFoundPage.mark()
+def custom_not_found_page():
+    return "Custom 404 Page"
+
+```
+!!! TIP
+    `NotFoundPage` contents is wrapped in an HTMLResponse with a status_code `404`.
+
+#### Forbidden Page - 403
+```python
+from easyauth.pages import ForbiddenPage
+
+@ForbiddenPage.mark()
+def not_allowed_page():
+    return "Custom 404 Page"
+```
+#### Login Page & 401
+```python
+from easyauth.pages import LoginPage
+
+@LoginPage.mark()
+def custom_login_page():
+    return "Custom Login Page"
+
+```
+
+#### Register Page
+```python
+from easyauth.pages import RegisterPage
+
+@RegisterPage.mark()
+def custom_register_page():
+    return "Custom Register Page"
+
+```
+
+#### Activation Page
+```python
+from easyauth.pages import ActivationPage
+
+@ActivationPage.mark()
+def custom_activation_page():
+    return "Custom Login Page"
+
+```

--- a/easyauth/frontend.py
+++ b/easyauth/frontend.py
@@ -16,6 +16,7 @@ from easyauth.models import (
     Tokens,
     Users,
 )
+from easyauth.pages import ActivationPage, RegisterPage
 
 
 async def frontend_setup(server):
@@ -1253,6 +1254,10 @@ async def frontend_setup(server):
 
     @server.server.get("/register", response_class=HTMLResponse, tags=["User"])
     async def admin_register():
+        return server.html_register_page()
+
+    @RegisterPage.mark()
+    def default_register_page():
         return register.get_register_user_page(
             form=forms.get_form(
                 title="Register User",
@@ -1275,6 +1280,10 @@ async def frontend_setup(server):
 
     @server.server.get("/activate", response_class=HTMLResponse, tags=["User"])
     async def admin_activate():
+        return server.html_activation_page()
+
+    @ActivationPage.mark()
+    def default_activation_page():
         return register.get_register_user_page(
             title="Activate user",
             welcome_message="Activate your account",

--- a/easyauth/pages.py
+++ b/easyauth/pages.py
@@ -1,0 +1,58 @@
+class LoginPage:
+    parent: None  # EasyAuthServer / EasyAuthClient
+
+    @classmethod
+    def mark(cls):
+        def override(func):
+            cls.parent.html_login_page = func
+            return func
+
+        return override
+
+
+class RegisterPage:
+    parent: None  # EasyAuthServer / EasyAuthClient
+
+    @classmethod
+    def mark(cls):
+        def override(func):
+            cls.parent.html_register_page = func
+            return func
+
+        return override
+
+
+class ActivationPage:
+    parent: None  # EasyAuthServer / EasyAuthClient
+
+    @classmethod
+    def mark(cls):
+        def override(func):
+            cls.parent.html_activation_page = func
+            return func
+
+        return override
+
+
+class NotFoundPage:
+    parent: None  # EasyAuthServer / EasyAuthClient
+
+    @classmethod
+    def mark(cls):
+        def override(func):
+            cls.parent.html_not_found_page = func
+            return func
+
+        return override
+
+
+class ForbiddenPage:
+    parent: None  # EasyAuthServer / EasyAuthClient
+
+    @classmethod
+    def mark(cls):
+        def override(func):
+            cls.parent.html_forbidden_page = func
+            return func
+
+        return override


### PR DESCRIPTION
## Description
This PR implements default html page overloading, & client default_login_path overrides. 

### Page Overloads
It is possible to overload the existing login, register, activation, not_found, and forbidden pages using the page specific "overloader". Just like routers, this should be done after an EasyAuthClient is created.

#### Not Found - 404
```python
from easyauth.pages import NotFoundPage

@NotFoundPage.mark()
def custom_not_found_page():
    return "Custom 404 Page"

```

#### Forbidden Page - 403
```python
from easyauth.pages import ForbiddenPage

@ForbiddenPage.mark()
def not_allowed_page():
    return "Custom 404 Page"
```
#### Login Page & 401
```python
from easyauth.pages import LoginPage

@LoginPage.mark()
def custom_login_page():
    return "Custom Login Page"

```

#### Register Page
```python
from easyauth.pages import RegisterPage

@RegisterPage.mark()
def custom_register_page():
    return "Custom Register Page"

```

#### Activation Page
```python
from easyauth.pages import ActivationPage

@ActivationPage.mark()
def custom_activation_page():
    return "Custom Login Page"

```

### Path Overloads
The default `/login` and 401 redirect path can be overloaded by setting the `default_login_path` on `EasyAuthClient.create()`.

```python
    server.auth = await EasyAuthClient.create(
        server,
        token_server='0.0.0.0',
        token_server_port=8090,
        auth_secret='abcd1234',
        default_permissions={'groups': ['users']},
        default_login_path='/v1/internal/login'
    )
```