### PR TITLE
Add get user functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ uvicorn --host 0.0.0.0 --port 8330 test_server:server
 from fastapi import FastAPI
 
 from easyauth.client import EasyAuthClient
+from easyauth import get_user
 
 server = FastAPI()
 
@@ -110,8 +111,8 @@ async def startup():
 
     # grants access to members of 'users' or 'admins' group.
     @server.auth.get('/groups', groups=['users', 'admins'])
-    async def groups():
-        return f"I am groups"
+    async def groups(user: str = get_user()):
+        return f"{user} is in groups"
 
     # grants access to all members of 'users' group
     # or a groups with role of 'basic' or advanced

--- a/docs/client_usage.md
+++ b/docs/client_usage.md
@@ -6,6 +6,7 @@
 #test_client.py
 from fastapi import FastAPI
 
+from easyauth import get_user
 from easyauth.client import EasyAuthClient
 
 server = FastAPI()
@@ -32,8 +33,8 @@ async def startup():
 
     # grants access to members of 'users' or 'admins' group.
     @server.auth.get('/groups', groups=['users', 'admins'])
-    async def groups():
-        return f"I am groups"
+    async def groups(user: get_user()):
+        return f"{user} is in groups"
 
     # grants access to all members of 'users' group
     # or a groups with role of 'basic' or advanced

--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -69,3 +69,32 @@ EasyAuthServer updates all EasyAuthServer workers & connected EasyAuthClients wh
 
 !!! TIP
     Tokens listed in the registry are seen as valid, and tokens which are revoked or do not exist in the registry, will return a 403.
+
+#### Get Current User
+Both EasyAuthServer / EasyAuthClients can determine the current user accessing an endpoint by adding `user: str = get_user()` to any easyauth decorated endpoint:
+
+
+```python
+#test_client.py
+from fastapi import FastAPI
+
+from easyauth.client import EasyAuthClient
+from easyauth import get_user
+
+server = FastAPI()
+
+@server.on_event('startup')
+async def startup():
+    server.auth = await EasyAuthClient.create(
+        server,
+        token_server='0.0.0.0',
+        token_server_port=8090,
+        auth_secret='abcd1234',
+        default_permissions={'groups': ['users']}
+    )
+
+    # grants access to users matching default_permissions
+    @server.auth.get('/default')
+    async def default(user: str = get_user()):
+        return f"{user} is accessing default endpoint"
+```

--- a/docs/server_usage.md
+++ b/docs/server_usage.md
@@ -101,6 +101,7 @@ async def startup():
 
 ```python
 from easyauth.router import EasyAuthAPIRouter
+from easyauth import get_user
 
 finance_router = EasyAuthAPIRouter.create(prefix='/finance', tags=['finance'])
 
@@ -109,8 +110,8 @@ async def finance_root():
     return f"fiance_root"
 
 @router.get('/data')
-async def finance_data():
-    return f"finance_data"
+async def finance_data(user: get_user()):
+    return f"{user} can access finance_data"
 
 ```
 !!! TIP
@@ -155,6 +156,7 @@ The EasyAuth Admin GUI is accessible by accessing the listening host:port at the
 ![](images/admin_gui.png)
 
 ### Docker
+The latest container TAGs are available on [DockerHub](https://hub.docker.com/r/joshjamison/easyauth), the latest tag will match the latest PYPI version.
 
 #### Start Auth Server
 

--- a/easyauth/__init__.py
+++ b/easyauth/__init__.py
@@ -1,0 +1,1 @@
+from .utils import get_user

--- a/easyauth/utils.py
+++ b/easyauth/utils.py
@@ -1,0 +1,24 @@
+import jwt
+from fastapi import Depends, Request
+
+
+def get_user():
+    def get_user_handler(request: Request):
+        if "token" not in request.cookies and not "Authorization" in request.headers:
+            return None
+
+        if "token" in request.cookies:
+            decoded_token = jwt.decode(
+                request.cookies["token"], options={"verify_signature": False}
+            )
+            return decoded_token["permissions"]["users"][0]
+        elif "Authorization" in request.headers:
+            # header should be separated by 'Bearer <tokenstr>'
+            decoded_token = jwt.decode(
+                request.headers["Authorization"].split(" ")[1],
+                options={"verify_signature": False},
+            )
+            return decoded_token["permissions"]["users"][0]
+        return None
+
+    return Depends(get_user_handler)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,8 +7,7 @@ import requests
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from easyauth.client import EasyAuthClient
-from easyauth.pages import NotFoundPage
+from easyauth import get_user
 from easyauth.router import EasyAuthAPIRouter
 from easyauth.server import EasyAuthServer
 
@@ -154,6 +153,10 @@ async def auth_test_server(db_config):
         @test_auth_router.get("/actions", actions=["BASIC_CREATE"])
         async def action():
             return "I am actions"
+
+        @test_auth_router.get("/current_user", users=["john"])
+        async def current_user(user: str = get_user()):
+            return user
 
     with TestClient(server) as test_client:
         yield test_client

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -188,19 +188,31 @@ async def test_server_authentication(auth_test_server):
         response.status_code == 200
     ), f"update group {response.text} - {response.status_code}"
 
-    # verify permissoin denied without required action
+    # verify permission denied without required action
     response = test_client.get("/testing/actions", headers=headers)
     assert response.status_code == 403, f"{response.text} - {response.status_code}"
 
-    # verify permissoin denied without required role
+    # verify permission denied without required role
     response = test_client.get("/testing/roles", headers=headers)
     assert response.status_code == 403, f"{response.text} - {response.status_code}"
 
-    # verify permissoin denied without required group
+    # verify permission denied without required group
     response = test_client.get("/testing/groups", headers=headers)
     assert response.status_code == 403, f"{response.text} - {response.status_code}"
 
-    # verify permissoin allowed for specific user
+    # test get_user {'Authorization': 'Bearer tokenstr'}
+    response = test_client.get("/testing/current_user", headers=headers)
+    assert response.status_code == 200, f"{response.text} - {response.status_code}"
+    assert "john" in response.text
+
+    # test get_user - cookie only header
+    token = headers["Authorization"].split(" ")[1]
+    cookie_only = {"cookie": f"token={token}"}
+    response = test_client.get("/testing/current_user", headers=cookie_only)
+    assert response.status_code == 200, f"{response.text} - {response.status_code}"
+    assert "john" in response.text
+
+    # verify permission allowed for specific user
     response = test_client.get("/testing/", headers=headers)
     assert response.status_code == 200, f"{response.text} - {response.status_code}"
 
@@ -215,11 +227,11 @@ async def test_server_authentication(auth_test_server):
     response = test_client.get("/testing/actions", headers=headers)
     assert response.status_code == 403, f"{response.text} - {response.status_code}"
 
-    # verify permissoin denied without required action
+    # verify permission denied without required action
     response = test_client.get("/testing/roles", headers=headers)
     assert response.status_code == 403, f"{response.text} - {response.status_code}"
 
-    # verify permissoin denied without required action
+    # verify permission denied without required action
     response = test_client.get("/testing/groups", headers=headers)
     assert response.status_code == 403, f"{response.text} - {response.status_code}"
 
@@ -241,13 +253,13 @@ async def test_server_authentication(auth_test_server):
         response.status_code == 200
     ), f"new_token - actions {response.text} - {response.status_code}"
 
-    # verify permissoin denied without required action
+    # verify permission denied without required action
     response = test_client.get("/testing/roles", headers=headers)
     assert (
         response.status_code == 200
     ), f"new_token - roles {response.text} - {response.status_code}"
 
-    # verify permissoin denied without required action
+    # verify permission denied without required action
     response = test_client.get("/testing/groups", headers=headers)
     assert (
         response.status_code == 200


### PR DESCRIPTION
## Description
This PR adds `get_user()` functionality to easyauth decorated endpoints.


### Example
```python
from fastapi import FastAPI

from easyauth.client import EasyAuthClient
from easyauth import get_user

server = FastAPI()

@server.on_event('startup')
async def startup():
    server.auth = await EasyAuthClient.create(
        server,
        token_server='0.0.0.0',
        token_server_port=8090,
        auth_secret='abcd1234',
        default_permissions={'groups': ['users']}
    )

    # grants access to users matching default_permissions
    @server.auth.get('/default')
    async def default(user: str = get_user()):
        return f"{user} is accessing default endpoint"
``` 